### PR TITLE
Hide gift cards from listing

### DIFF
--- a/graphql/ProductList.graphql
+++ b/graphql/ProductList.graphql
@@ -2,7 +2,7 @@ query ProductList {
 	products(
 		first: 1
 		channel: "default-channel"
-		where: { isAvailable: true }
+		where: { isAvailable: true, isPublished: true, giftCard: false, isVisibleInListing: true }
 		sortBy: { field: PRICE, direction: DESC }
 	) {
 		edges {


### PR DESCRIPTION
This PR hides gift cards from listing: they don't require a shipping address, thus testing the full payment flow is impossible with them